### PR TITLE
ci: skip auto-assign-pr reviewer request for renovate[bot] PRs

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -19,7 +19,7 @@ jobs:
             assignees: modem7
 
   auto-assign-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary
- `auto-assign-pr` was requesting a review from modem7 on every PR, including ones opened by `renovate[bot]`
- Adds `&& github.actor != 'renovate[bot]'` to the job condition so Renovate PRs no longer get a review request

## Test plan
- [ ] Confirm the workflow still runs and assigns a reviewer on a human-opened PR
- [ ] Confirm no review request appears on the next renovate[bot] PR