### PR TITLE
Fix Alpine_Python: python:alpine3.17 is EOL, breaks multi-arch publish

### DIFF
--- a/Environments/Alpine_Python/Dockerfile
+++ b/Environments/Alpine_Python/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM python:alpine3.17
+FROM python:alpine
 LABEL maintainer="modem7"
 
 ARG EXTRA_PACKAGES=""


### PR DESCRIPTION
## Summary
The publish workflow's multi-arch (amd64+arm64) build for `Alpine_Python` failed after merging #14: Alpine 3.17 is long past end-of-life and its package repositories are gone from the mirrors GitHub Actions runners hit, so `apk add` failed with "no such package" for every package in the requirements list.

Switches `FROM python:alpine3.17` to `FROM python:alpine` (tracks latest), matching every other environment in this repo - none of them pin a specific distro version, by design.

## Test plan
- [x] hadolint clean
- [x] Single-arch (amd64) build succeeds, /workspace + python3 --version confirmed
- [x] Real multi-arch (linux/amd64,linux/arm64) buildx build reproducing publish.yml's exact scenario succeeds locally
- [ ] publish.yml passes for Alpine_Python once this merges (verify in Actions tab)